### PR TITLE
Upgrade to Alfy v0.9.x to add Alfred 4 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   ],
   "dependencies": {
     "@vitalets/google-translate-api": "^2.8.0",
-    "alfy": "^0.6.0"
+    "alfy": "^0.9.0"
   },
   "devDependencies": {
     "xo": "^0.20.3"


### PR DESCRIPTION
See sindresorhus/alfy#100, which allows for alfred-link v0.3.1, which has the fix for Alfred 4